### PR TITLE
Add mobile-friendly HTML output

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Book Tools helps you create beautiful books in multiple formats (PDF, EPUB, MOBI
 - 🔧 **GitHub Actions**: Built-in CI/CD workflows for automated builds
 - 📝 **Markdown-based**: Write in plain text with rich formatting options
 - 🎨 **Customizable**: Templates, styles, and formatting options
+- 📱 **Mobile-friendly HTML**: Responsive design for better reading on all devices
 
 ## Overview
 
@@ -26,6 +27,7 @@ Book Tools provides a comprehensive suite of tools for book creation and managem
 - **Verbose Mode**: Detailed output options for debugging and progress tracking
 - **Docker Support**: Containerized building with all dependencies included
 - **GitHub Actions**: Built-in CI/CD workflows for automated builds and releases
+- **Mobile-friendly HTML**: Responsive output with image scaling for better reading on all devices
 
 This project provides shell scripts for building books from markdown files using Pandoc and other tools. The scripts handle:
 
@@ -293,6 +295,9 @@ pdf:
 epub:
   coverImage: "book/images/cover.png"
   css: "templates/epub/style.css"
+  
+html:
+  responsive: true  # Enable/disable mobile-friendly features
 ```
 
 ### File Naming
@@ -311,6 +316,16 @@ Your output files will be named:
 - `my-awesome-book.docx`
 
 If not specified, the default behavior is to use `book` as the file prefix.
+
+## Mobile-Friendly HTML
+
+The HTML output is now mobile-friendly by default, with responsive features that make your book look great on all devices. Key features include:
+
+- Viewport meta tag for proper scaling on mobile devices
+- Responsive image handling with automatic scaling to fit screen width
+- Media queries for different device sizes
+
+For more details, see the [Mobile-Friendly HTML documentation](docs/mobile-friendly-html.md).
 
 ## Testing
 

--- a/docs/mobile-friendly-html.md
+++ b/docs/mobile-friendly-html.md
@@ -1,0 +1,111 @@
+# Mobile-Friendly HTML Output
+
+This feature enhances the HTML output from Book Tools to be more mobile-friendly, particularly for handling large images (like 1024x1024 images) on smaller screens.
+
+## Features
+
+- Viewport meta tag for proper scaling on mobile devices
+- Responsive image handling with automatic scaling to fit screen width
+- Appropriate padding for images on different device sizes
+- Media queries to adjust layout for different screen widths
+- Better table handling with horizontal scrolling on small screens
+
+## Configuration
+
+Mobile-friendly HTML is enabled by default. You can configure it in your `book.yaml` file:
+
+```yaml
+html:
+  responsive: true  # Set to false to disable responsive features
+  # Other HTML settings...
+```
+
+## How It Works
+
+When responsive HTML is enabled (the default), Book Tools will:
+
+1. Use the responsive HTML template (`templates/html/responsive.html`) if available
+2. Use the responsive CSS stylesheet (`templates/html/responsive.css`) if available
+3. Fall back to the default templates with basic responsive features if the specialized files aren't found
+
+## Custom Styling
+
+You can customize the responsive styling by:
+
+1. Editing the `templates/html/responsive.css` file directly
+2. Specifying your own CSS file in the configuration:
+
+```yaml
+html:
+  css: path/to/your/custom.css
+  responsive: false  # Use this to bypass the responsive template and just use your CSS
+```
+
+## Technical Details
+
+### Responsive Image Handling
+
+Images are styled with:
+
+```css
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+  padding: 10px;
+  box-sizing: border-box;
+}
+```
+
+This ensures that:
+- Images never exceed the width of their container
+- Images maintain their aspect ratio
+- Images are centered with appropriate padding
+
+### Viewport Configuration
+
+The HTML templates include:
+
+```html
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+```
+
+This tells mobile browsers to:
+- Set the viewport width to the device width
+- Set the initial zoom level to 1.0 (no zooming)
+
+### Media Queries
+
+The CSS includes media queries for different screen sizes:
+
+```css
+@media only screen and (max-width: 768px) {
+  /* Tablet styles */
+}
+
+@media only screen and (max-width: 480px) {
+  /* Mobile phone styles */
+}
+```
+
+## Troubleshooting
+
+### Images Still Too Large
+
+If images are still too large or not scaling properly:
+
+1. Verify that the responsive feature is enabled in your configuration
+2. Check that the HTML output includes the viewport meta tag
+3. Ensure the CSS is properly loading in the generated HTML file
+
+### Text Size Issues
+
+If text is too small on mobile devices:
+
+1. Add custom font sizing in your CSS for smaller screens
+2. Use relative units (em, rem) instead of pixels for font sizes
+
+### Layout Problems
+
+If you encounter layout issues with specific content types, you may need to add additional CSS rules for those elements.

--- a/src/config.js
+++ b/src/config.js
@@ -37,6 +37,9 @@ function loadExtendedConfig(config) {
   config.formatSettings.html.tocDepth = config.formatSettings.html.tocDepth || config.html?.toc_depth || 3;
   config.formatSettings.html.sectionDivs = config.formatSettings.html.sectionDivs || config.html?.section_divs || true;
   config.formatSettings.html.selfContained = config.formatSettings.html.selfContained || config.html?.self_contained || true;
+  // Add responsive option, default to true
+  config.formatSettings.html.responsive = config.formatSettings.html.responsive !== undefined ? 
+    config.formatSettings.html.responsive : config.html?.responsive !== false;
   
   // MOBI configuration - minimal for now
   config.formatSettings.mobi = config.formatSettings.mobi || {};
@@ -175,7 +178,7 @@ function getDefaultConfig() {
  */
 function safeQuote(str) {
   // Replace double quotes with escaped double quotes
-  const escaped = str.replace(/"/g, '\\"');
+  const escaped = str.replace(/\"/g, '\\\"');
   // Wrap in double quotes
   return `"${escaped}"`;
 }
@@ -263,12 +266,32 @@ function getPandocArgs(config, format, language) {
   } else if (format === 'html') {
     const htmlSettings = formatSettings.html || {};
     
-    if (htmlSettings.template && fs.existsSync(htmlSettings.template)) {
-      args.push(`--template=${safeQuote(htmlSettings.template)}`);
-    }
-    
-    if (htmlSettings.css && fs.existsSync(htmlSettings.css)) {
-      args.push(`--css=${safeQuote(htmlSettings.css)}`);
+    // Use responsive template and CSS if the responsive option is enabled
+    if (htmlSettings.responsive !== false) {
+      // Check for responsive template
+      const responsiveTemplate = path.join(process.cwd(), 'templates/html/responsive.html');
+      if (fs.existsSync(responsiveTemplate)) {
+        args.push(`--template=${safeQuote(responsiveTemplate)}`);
+      } else if (htmlSettings.template && fs.existsSync(htmlSettings.template)) {
+        args.push(`--template=${safeQuote(htmlSettings.template)}`);
+      }
+      
+      // Check for responsive CSS
+      const responsiveCSS = path.join(process.cwd(), 'templates/html/responsive.css');
+      if (fs.existsSync(responsiveCSS)) {
+        args.push(`--css=${safeQuote(responsiveCSS)}`);
+      } else if (htmlSettings.css && fs.existsSync(htmlSettings.css)) {
+        args.push(`--css=${safeQuote(htmlSettings.css)}`);
+      }
+    } else {
+      // Use standard (non-responsive) templates
+      if (htmlSettings.template && fs.existsSync(htmlSettings.template)) {
+        args.push(`--template=${safeQuote(htmlSettings.template)}`);
+      }
+      
+      if (htmlSettings.css && fs.existsSync(htmlSettings.css)) {
+        args.push(`--css=${safeQuote(htmlSettings.css)}`);
+      }
     }
     
     if (htmlSettings.toc !== false) {

--- a/templates/html/default.html
+++ b/templates/html/default.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>$title$</title>
   $if(css)$
   <link rel="stylesheet" href="$css$">
@@ -10,6 +11,7 @@
   <style>
     body { font-family: sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; }
     h1, h2, h3 { color: #333; }
+    img { max-width: 100%; height: auto; }
   </style>
   $endif$
 </head>

--- a/templates/html/responsive.css
+++ b/templates/html/responsive.css
@@ -1,0 +1,153 @@
+/* Base styles */
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  line-height: 1.6;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+  color: #333;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: #222;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+a {
+  color: #0066cc;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+code {
+  background-color: #f5f5f5;
+  padding: 2px 4px;
+  border-radius: 3px;
+  font-family: monospace;
+}
+
+pre {
+  background-color: #f5f5f5;
+  padding: 1em;
+  border-radius: 5px;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+/* Table styles with horizontal scroll for mobile */
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1em 0;
+  overflow-x: auto;
+  display: block;
+}
+
+thead {
+  background-color: #f2f2f2;
+}
+
+th, td {
+  padding: 8px;
+  text-align: left;
+  border-bottom: 1px solid #ddd;
+}
+
+/* Enhanced image styling for better mobile display */
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: 0 auto;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+figure {
+  max-width: 100%;
+  margin: 1.5em auto;
+}
+
+figcaption {
+  font-style: italic;
+  text-align: center;
+  font-size: 0.9em;
+  margin-top: 0.5em;
+}
+
+blockquote {
+  border-left: 4px solid #ddd;
+  padding-left: 1em;
+  margin-left: 0;
+  color: #666;
+}
+
+/* Navigation styles for Table of Contents */
+nav#TOC {
+  background-color: #f8f8f8;
+  padding: 1em;
+  border-radius: 5px;
+  margin-bottom: 2em;
+}
+
+nav#TOC ul {
+  padding-left: 1.5em;
+}
+
+/* Media queries for different screen sizes */
+@media only screen and (max-width: 768px) {
+  body {
+    padding: 15px;
+  }
+  
+  img {
+    padding: 5px;
+  }
+  
+  table {
+    font-size: 0.9em;
+  }
+  
+  nav#TOC {
+    padding: 0.8em;
+  }
+}
+
+@media only screen and (max-width: 480px) {
+  body {
+    padding: 10px;
+  }
+  
+  h1 {
+    font-size: 1.8em;
+  }
+  
+  h2 {
+    font-size: 1.5em;
+  }
+  
+  h3 {
+    font-size: 1.2em;
+  }
+  
+  pre, code {
+    font-size: 0.9em;
+    padding: 0.5em;
+  }
+  
+  nav#TOC {
+    font-size: 0.9em;
+  }
+}
+
+/* Optional: For very large screens */
+@media only screen and (min-width: 1600px) {
+  body {
+    max-width: 1000px;
+  }
+}

--- a/templates/html/responsive.html
+++ b/templates/html/responsive.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="$lang$">
+<head>
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>$title$</title>
+  $if(css)$
+  <link rel="stylesheet" href="$css$">
+  $else$
+  <style>
+    body {
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+      line-height: 1.6;
+      max-width: 800px;
+      margin: 0 auto;
+      padding: 20px;
+      color: #333;
+    }
+    
+    h1, h2, h3, h4, h5, h6 {
+      color: #222;
+      margin-top: 1.5em;
+      margin-bottom: 0.5em;
+    }
+    
+    img {
+      max-width: 100%;
+      height: auto;
+      display: block;
+      margin: 0 auto;
+      padding: 10px;
+      box-sizing: border-box;
+    }
+    
+    figure {
+      max-width: 100%;
+      margin: 1.5em auto;
+    }
+    
+    figcaption {
+      font-style: italic;
+      text-align: center;
+      font-size: 0.9em;
+      margin-top: 0.5em;
+    }
+    
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 1em 0;
+      overflow-x: auto;
+      display: block;
+    }
+    
+    pre {
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-wrap: break-word;
+    }
+    
+    @media only screen and (max-width: 768px) {
+      body {
+        padding: 15px;
+      }
+      
+      img {
+        padding: 5px;
+      }
+    }
+    
+    @media only screen and (max-width: 480px) {
+      body {
+        padding: 10px;
+      }
+      
+      h1 {
+        font-size: 1.8em;
+      }
+      
+      h2 {
+        font-size: 1.5em;
+      }
+    }
+  </style>
+  $endif$
+  $for(header-includes)$
+  $header-includes$
+  $endfor$
+</head>
+<body>
+  <header>
+    <h1>$title$</h1>
+    $if(subtitle)$<h2>$subtitle$</h2>$endif$
+    $if(author)$<p>$author$</p>$endif$
+  </header>
+  $if(toc)$
+  <nav id="$idprefix$TOC">
+    $table-of-contents$
+  </nav>
+  $endif$
+  <main>
+    $body$
+  </main>
+  $if(include-after)$
+  $for(include-after)$
+  $include-after$
+  $endfor$
+  $endif$
+</body>
+</html>

--- a/templates/html/style.css
+++ b/templates/html/style.css
@@ -40,6 +40,8 @@ table {
   border-collapse: collapse;
   width: 100%;
   margin: 1em 0;
+  overflow-x: auto;
+  display: block;
 }
 
 th, td {
@@ -52,9 +54,26 @@ th {
   background-color: #f2f2f2;
 }
 
+/* Enhanced image styling */
 img {
   max-width: 100%;
   height: auto;
+  display: block;
+  margin: 0 auto;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+figure {
+  max-width: 100%;
+  margin: 1.5em auto;
+}
+
+figcaption {
+  font-style: italic;
+  text-align: center;
+  font-size: 0.9em;
+  margin-top: 0.5em;
 }
 
 blockquote {
@@ -62,4 +81,29 @@ blockquote {
   padding-left: 1em;
   margin-left: 0;
   color: #666;
+}
+
+/* Basic responsive adjustments */
+@media only screen and (max-width: 768px) {
+  body {
+    padding: 15px;
+  }
+  
+  img {
+    padding: 5px;
+  }
+}
+
+@media only screen and (max-width: 480px) {
+  body {
+    padding: 10px;
+  }
+  
+  h1 {
+    font-size: 1.8em;
+  }
+  
+  h2 {
+    font-size: 1.5em;
+  }
 }


### PR DESCRIPTION
This PR adds mobile-friendly HTML output capabilities to the book-tools package.

## Features

- Adds viewport meta tag for proper scaling on mobile devices
- Implements responsive image handling for 1024x1024 images
- Includes media queries for different screen sizes
- Adds padding and margin to images for better presentation
- Makes tables horizontally scrollable on small screens

## Implementation

1. Added responsive HTML template and CSS
2. Updated config.js to support a new 'responsive' option (enabled by default)
3. Enhanced the default HTML template and CSS with basic responsive features
4. Added documentation for the mobile-friendly HTML feature

## Configuration

This feature is enabled by default but can be disabled in book.yaml if needed:

```yaml
html:
  responsive: false  # Disable responsive features
```

## Testing

The changes have been tested with different screen sizes and devices to ensure proper scaling and display of book content, particularly with large 1024x1024 images.

## Documentation

Added a new documentation file at `docs/mobile-friendly-html.md` with details about the feature and updated the main README.md.